### PR TITLE
Add possibility to translate the text "Dismiss"

### DIFF
--- a/Sources/FSCheckoutSheet/FSCheckoutSheet.swift
+++ b/Sources/FSCheckoutSheet/FSCheckoutSheet.swift
@@ -152,7 +152,7 @@ public final class FastSpringCheckoutVC: NSViewController {
     webView.navigationDelegate = self
     
     let buttonStack = NSStackView(views: [
-      NSButton(title  : "Dismiss", // TODO: Loc
+      NSButton(title  : NSLocalizedString("Dismiss", comment: "Dismiss Button Caption"),
                target : nil, action: #selector(cancelOperation(_:)))
     ])
     buttonStack.orientation = .horizontal


### PR DESCRIPTION
If no translation is defined, the default text "Dismiss" will be displayed. If a translation is defined, the translation will be taken automatically.